### PR TITLE
Add server side event registration

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace VincentBean\LaravelPlausible;
+
+use Illuminate\Support\Facades\Http;
+
+class Event
+{
+    public static function fire(string $name, array $props = [], array $args = []): bool
+    {
+        return Http::withHeaders([
+            'X-Forwarded-For' => request()->ip(),
+            'user-agent'      => request()->userAgent(),
+        ])
+            ->post(
+                config('laravel-plausible.plausible_domain').'/api/event',
+                array_merge($args, [
+                    'name'   => $name,
+                    'domain' => config('laravel-plausible.tracking_domain'),
+                    'url'    => $args['url'] ?? url()->current(),
+                    'props'  => json_encode($props),
+                ])
+            )
+            ->successful();
+
+    }
+}


### PR DESCRIPTION
This PR adds a class to record server side events.

It could be used for example to register a double opt in mail on the server.

PS. Could the `hacktoberfest-accepted` label be added to this PR? 😄 🚀 