### PR TITLE
Track pageviews server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Include the view in your layout
 @include('plausible::tracking')
 ```
 
+Track pageviews server side using middleware
+
+```php
+// app/Http/Kernel.php
+    'web' => [
+        \VincentBean\LaravelPlausible\Middleware\TrackPlausiblePageviews::class, // Add this middleware to the web group to track globally
+    ],
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/Middleware/TrackPlausiblePageviews.php
+++ b/src/Middleware/TrackPlausiblePageviews.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use VincentBean\LaravelPlausible\Event;
+
+class TrackPlausiblePageviews
+{
+    public function handle(Request $request, Closure $next)
+    {
+        Event::fire('pageview');
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR adds a simple middleware that can be used to track pageviews from the server. This can prevent the tracking from being blocked by blockers.