### PR TITLE
Add Test Suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore
+/phpunit.xml        export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
 /.php_cs.dist       export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,41 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        php: [8.0]
+        laravel: [8.*]
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 8.*
+            testbench: ^6.6
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ build
 composer.lock
 coverage
 docs
-phpunit.xml
 psalm.xml
 testbench.yaml
 vendor

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,17 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "guzzlehttp/guzzle": "^7.4",
         "illuminate/contracts": "^8.37"
     },
     "autoload": {
         "psr-4": {
             "VincentBean\\LaravelPlausible\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "VincentBean\\LaravelPlausible\\Tests\\": "tests"
         }
     },
     "config": {
@@ -35,5 +41,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "orchestra/testbench": "^6.20"
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./app</directory>
+      <directory suffix=".php">./src</directory>
     </include>
   </coverage>
   <testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="APP_KEY" value="base64:jsP4EW3mcB1JuHjWph1ZLZnobaCEq1zvC2B6feODF38="/>
+    <server name="BCRYPT_ROUNDS" value="4"/>
+    <server name="CACHE_DRIVER" value="array"/>
+    <server name="MAIL_MAILER" value="array"/>
+    <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="SESSION_DRIVER" value="array"/>
+  </php>
+</phpunit>

--- a/src/LaravelPlausibleServiceProvider.php
+++ b/src/LaravelPlausibleServiceProvider.php
@@ -3,8 +3,6 @@
 namespace VincentBean\LaravelPlausible;
 
 use Illuminate\Support\ServiceProvider;
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class LaravelPlausibleServiceProvider extends ServiceProvider
 {

--- a/src/PlausibleEvent.php
+++ b/src/PlausibleEvent.php
@@ -10,18 +10,17 @@ class PlausibleEvent
     {
         return Http::withHeaders([
             'X-Forwarded-For' => request()->ip(),
-            'user-agent'      => request()->userAgent(),
+            'user-agent' => request()->userAgent(),
         ])
             ->post(
                 config('laravel-plausible.plausible_domain').'/api/event',
                 array_merge($args, [
-                    'name'   => $name,
+                    'name' => $name,
                     'domain' => config('laravel-plausible.tracking_domain'),
-                    'url'    => $args['url'] ?? url()->current(),
-                    'props'  => json_encode($props),
+                    'url' => $args['url'] ?? url()->current(),
+                    'props' => json_encode($props),
                 ])
             )
             ->successful();
-
     }
 }

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,2 +1,2 @@
 providers:
-  - VincentBean\LaravelPlausible\SkeletonServiceProvider
+  - VincentBean\LaravelPlausible\LaravelPlausibleServiceProvider

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Tests;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected const PLAUSIBLE_TRACKING_DOMAIN = 'https://plausible-tracking-domain.test';
+    protected const PLAUSIBLE_DOMAIN = 'https://plausible-domain.test';
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            'VincentBean\LaravelPlausible\LaravelPlausibleServiceProvider',
+        ];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('laravel-plausible.tracking_domain', static::PLAUSIBLE_TRACKING_DOMAIN);
+        $app['config']->set('laravel-plausible.plausible_domain', static::PLAUSIBLE_DOMAIN);
+    }
+}

--- a/tests/Unit/PlausibleEventTest.php
+++ b/tests/Unit/PlausibleEventTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Tests\Unit;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use VincentBean\LaravelPlausible\PlausibleEvent;
+use VincentBean\LaravelPlausible\Tests\TestCase;
+
+class PlausibleEventTest extends TestCase
+{
+    use WithFaker;
+
+    public function testFireCustomUrl()
+    {
+        $post_url = static::PLAUSIBLE_DOMAIN . '/api/event';
+
+        Http::fake([
+            $post_url => Http::response('{}', Response::HTTP_ACCEPTED),
+        ]);
+
+        $url = $this->faker->url();
+        $name = $this->faker->word();
+        $props = [$this->faker->word() => $this->faker->word()];
+
+        PlausibleEvent::fire($name, $props, ['url' => $url]);
+
+        Http::assertSent(function (Request $request) use ($post_url, $url, $name, $props) {
+            return $request->hasHeader('X-Forwarded-For') &&
+                $request->hasHeader('user-agent') &&
+                $request->url() === $post_url &&
+                $request['name'] === $name &&
+                $request['domain'] === static::PLAUSIBLE_TRACKING_DOMAIN &&
+                $request['url'] === $url &&
+                $request['props'] === json_encode($props);
+        });
+    }
+
+    public function testFireCurrentUrl()
+    {
+        $post_url = static::PLAUSIBLE_DOMAIN . '/api/event';
+
+        Http::fake([
+            $post_url => Http::response('{}', Response::HTTP_ACCEPTED),
+        ]);
+
+        $name = $this->faker->word();
+        $props = [$this->faker->word() => $this->faker->word()];
+
+        PlausibleEvent::fire($name, $props);
+
+        Http::assertSent(function (Request $request) use ($post_url, $name, $props) {
+            return $request->hasHeader('X-Forwarded-For') &&
+                $request->hasHeader('user-agent') &&
+                $request->url() === $post_url &&
+                $request['name'] === $name &&
+                $request['domain'] === static::PLAUSIBLE_TRACKING_DOMAIN &&
+                $request['url'] === url()->current() &&
+                $request['props'] === json_encode($props);
+        });
+    }
+}

--- a/tests/Unit/TrackPlausiblePageviewsTest.php
+++ b/tests/Unit/TrackPlausiblePageviewsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Tests\Unit;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use VincentBean\LaravelPlausible\Middleware\TrackPlausiblePageviews;
+use VincentBean\LaravelPlausible\Tests\TestCase;
+
+class TrackPlausiblePageviewsTest extends TestCase
+{
+    use WithFaker;
+
+    public function testMiddleware()
+    {
+        $post_url = static::PLAUSIBLE_DOMAIN . '/api/event';
+
+        Http::fake([
+            $post_url => Http::response('{}', Response::HTTP_ACCEPTED),
+        ]);
+
+        $request = new \Illuminate\Http\Request();
+        $middleware = new TrackPlausiblePageviews();
+        $middleware->handle($request, function () use ($post_url) {
+            Http::assertSent(function (\Illuminate\Http\Client\Request $request) use ($post_url) {
+                return $request->hasHeader('X-Forwarded-For') &&
+                    $request->hasHeader('user-agent') &&
+                    $request->url() === $post_url &&
+                    $request['name'] === 'pageview' &&
+                    $request['domain'] === static::PLAUSIBLE_TRACKING_DOMAIN &&
+                    $request['url'] === url()->current() &&
+                    $request['props'] === json_encode([]);
+            });
+        });
+    }
+}

--- a/tests/Unit/TrackingSnippetTest.php
+++ b/tests/Unit/TrackingSnippetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Tests\Unit;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use VincentBean\LaravelPlausible\Tests\TestCase;
+
+class TrackingSnippetTest extends TestCase
+{
+    use InteractsWithViews;
+
+    public function testRenderSnippet()
+    {
+        $tracking_domain = config('laravel-plausible.tracking_domain');
+        $domain = config('laravel-plausible.plausible_domain');
+
+        $this->view('plausible::tracking')
+            ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/plausible.js\"></script>", false)
+            ->assertSee("<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>", false);
+    }
+}


### PR DESCRIPTION
- Adds `orchestra/testbench` to dev requirements
- Adds `guzzlehttp/guzzle` to requirements (required to use `Http` facade)
- Adds unit tests for firing events, middleware, and blade snippet
- Add GitHub Actions configuration to run tests on push and pull request
- Corrects code style based upon preexisting rules