### PR TITLE
New component with support for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ PLAUSIBLE_DOMAIN=OPTIONAL_IF_SELF_HOSTING
 This package supports both client side and server side tracking.
 
 ### Client Side Tracking
-Include the view in your layout to include the plausible script.
+Include the component in your layout to add the plausible script, with optional tracking extensions.
 ```php
-@include('plausible::tracking')
+<x-plausible::tracking /> 
+or 
+<x-plausible::tracking extensions="hash, outbound-links, etc.." />
 ```
 
 Plausible will be available on the window object for sending custom events via Javascript:

--- a/resources/views/components/tracking.blade.php
+++ b/resources/views/components/tracking.blade.php
@@ -1,0 +1,3 @@
+@if (config('laravel-plausible.tracking_domain', null))
+<script defer {{ $attributes->merge(['data-domain' => $trackingDomain, 'src' => $src]) }}></script>
+@endif

--- a/resources/views/components/tracking.blade.php
+++ b/resources/views/components/tracking.blade.php
@@ -1,3 +1,3 @@
 @if (config('laravel-plausible.tracking_domain', null))
-<script defer {{ $attributes->merge(['data-domain' => $trackingDomain, 'src' => $src]) }}></script>
+<script defer {{ $attributes->merge(['data-domain' => $trackingDomain, 'src' => $src])->except('extensions') }}></script>
 @endif

--- a/resources/views/tracking.blade.php
+++ b/resources/views/tracking.blade.php
@@ -1,4 +1,4 @@
 @if (config('laravel-plausible.tracking_domain', null))
-<script defer data-domain="{{ config('laravel-plausible.tracking_domain') }}" src="{{ config('laravel-plausible.plausible_domain') }}/js/plausible.js"></script>
+<script defer data-domain="{{ config('laravel-plausible.tracking_domain') }}" src="{{ config('laravel-plausible.plausible_domain') }}/js/script.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 @endif

--- a/src/Components/Tracking.php
+++ b/src/Components/Tracking.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace VincentBean\LaravelPlausible\Components;
+
+use Illuminate\View\Component;
+
+class Tracking extends Component
+{
+    public string $src;
+
+    public function __construct(
+        public ?string $trackingDomain = null,
+        public ?string $plausibleDomain = null,
+        public array|string|null $extensions = null
+    ) {
+        $this->trackingDomain ??= config('laravel-plausible.tracking_domain');
+        $this->plausibleDomain ??= config('laravel-plausible.plausible_domain');
+
+        if (!is_array($this->extensions)) {
+            $this->extensions = explode('.', (string) $this->extensions);
+        }
+
+        $this->src = implode('/', [
+            rtrim($this->plausibleDomain, '/'),
+            'js',
+            implode('.', [
+                'script',
+                ...array_filter($this->extensions),
+                'js'
+            ]),
+        ]);
+    }
+
+    public function render()
+    {
+        return view('plausible::components.tracking');
+    }
+}

--- a/src/Components/Tracking.php
+++ b/src/Components/Tracking.php
@@ -17,7 +17,10 @@ class Tracking extends Component
         $this->plausibleDomain ??= config('laravel-plausible.plausible_domain');
 
         if (!is_array($this->extensions)) {
-            $this->extensions = explode('.', (string) $this->extensions);
+            $this->extensions = array_map(
+                fn ($i) => trim($i),
+                explode(',', (string) $this->extensions)
+            );
         }
 
         $this->src = implode('/', [

--- a/src/LaravelPlausibleServiceProvider.php
+++ b/src/LaravelPlausibleServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace VincentBean\LaravelPlausible;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelPlausibleServiceProvider extends ServiceProvider
@@ -45,6 +46,8 @@ class LaravelPlausibleServiceProvider extends ServiceProvider
     protected function bootViews(): self
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'plausible');
+
+        Blade::componentNamespace('VincentBean\\LaravelPlausible\\Components', 'plausible');
 
         return $this;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace VincentBean\LaravelPlausible\Tests;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    protected const PLAUSIBLE_TRACKING_DOMAIN = 'https://plausible-tracking-domain.test';
+    protected const PLAUSIBLE_TRACKING_DOMAIN = 'plausible-tracking-domain.test';
     protected const PLAUSIBLE_DOMAIN = 'https://plausible-domain.test';
 
     protected function getPackageProviders($app): array

--- a/tests/Unit/TrackingSnippetTest.php
+++ b/tests/Unit/TrackingSnippetTest.php
@@ -15,7 +15,7 @@ class TrackingSnippetTest extends TestCase
         $domain = config('laravel-plausible.plausible_domain');
 
         $this->view('plausible::tracking')
-            ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/plausible.js\"></script>", false)
+            ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/script.js\"></script>", false)
             ->assertSee("<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>", false);
     }
 }

--- a/tests/Unit/TrackingSnippetTest.php
+++ b/tests/Unit/TrackingSnippetTest.php
@@ -27,8 +27,8 @@ class TrackingSnippetTest extends TestCase
         $this->blade('<x-plausible::tracking />')
             ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/script.js\"></script>", false);
 
-        $this->blade('<x-plausible::tracking tracking-domain="analytics.test.com" extensions="hash.outbound-links" />')
-            ->assertSee("<script defer data-domain=\"analytics.test.com\" src=\"$domain/js/script.hash.outbound-links.js\"></script>", false);
+        $this->blade('<x-plausible::tracking tracking-domain="analytics.test.com" extensions="hash,outbound-links, revenue" />')
+            ->assertSee("<script defer data-domain=\"analytics.test.com\" src=\"$domain/js/script.hash.outbound-links.revenue.js\"></script>", false);
 
         $this->blade('<x-plausible::tracking data-domain="analytics.test.com" extensions="hash.outbound-links" />')
             ->assertSee("<script defer data-domain=\"analytics.test.com\" src=\"$domain/js/script.hash.outbound-links.js\"></script>", false);

--- a/tests/Unit/TrackingSnippetTest.php
+++ b/tests/Unit/TrackingSnippetTest.php
@@ -18,4 +18,19 @@ class TrackingSnippetTest extends TestCase
             ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/script.js\"></script>", false)
             ->assertSee("<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>", false);
     }
+
+    public function testRenderComponent()
+    {
+        $tracking_domain = config('laravel-plausible.tracking_domain');
+        $domain = config('laravel-plausible.plausible_domain');
+
+        $this->blade('<x-plausible::tracking />')
+            ->assertSee("<script defer data-domain=\"$tracking_domain\" src=\"$domain/js/script.js\"></script>", false);
+
+        $this->blade('<x-plausible::tracking tracking-domain="analytics.test.com" extensions="hash.outbound-links" />')
+            ->assertSee("<script defer data-domain=\"analytics.test.com\" src=\"$domain/js/script.hash.outbound-links.js\"></script>", false);
+
+        $this->blade('<x-plausible::tracking data-domain="analytics.test.com" extensions="hash.outbound-links" />')
+            ->assertSee("<script defer data-domain=\"analytics.test.com\" src=\"$domain/js/script.hash.outbound-links.js\"></script>", false);
+    }
 }


### PR DESCRIPTION
This PR adds a new component and support for [tracking extensions](https://plausible.io/docs/script-extensions).

example usage:
```diff
-@include('plausible::tracking')
+<x-plausible::tracking extensions="hash, outbound-links, etc.." />
```

Because its a an component, you can easily add/overwrite attributes of the underlying `script` tag as well:
```blade
<x-plausible::tracking tracking-domain="my-domain.com" :src="$customScript" />
or 
<x-plausible::tracking data-domain="my-domain.com" :src="$customScript" />
```