### PR TITLE
Add support for setting a custom user_id fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ You can trigger custom events on the server.
 \VincentBean\LaravelPlausible\PlausibleEvent::fire('custom event', ['country' => 'netherlands']);
 ```
 
+If firing your event from a queued job or event listener, it might be necessary to pass on the user's `ip` and `user-agent` string which are used by Plausible to generate user session ID's.
+
+```php
+\VincentBean\LaravelPlausible\PlausibleEvent::fire('custom event', ['country' => 'netherlands'], headers: [
+    'X-Forwarded-For' => $event->userIp, 
+    'user-agent' => $event->userAgent
+]);
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/PlausibleEvent.php
+++ b/src/PlausibleEvent.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Facades\Http;
 
 class PlausibleEvent
 {
-    public static function fire(string $name, array $props = [], array $args = []): bool
+    public static function fire(string $name, array $props = [], array $args = [], array $headers = []): bool
     {
-        return Http::withHeaders([
+        return Http::withHeaders(array_merge([
             'X-Forwarded-For' => request()->ip(),
             'user-agent' => request()->userAgent(),
-        ])
+        ], $headers))
             ->post(
                 config('laravel-plausible.plausible_domain').'/api/event',
                 array_merge($args, [


### PR DESCRIPTION
This PR adds support for specifying the `ip address` and `user-agent` when firing an event.

This is necessary if sending events from a queued job where there is no `request` to pull from.