### PR TITLE
Support Laravel 11

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,6 +1,10 @@
 name: analyse
 
-on: ['push', 'pull_request']
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [opened, synchronize, reopened]
 
 jobs:
     test:
@@ -9,18 +13,15 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2]
-                laravel: [10.*]
+                php: [8.2, 8.3]
+                laravel: ['10.*', '11.*']
                 stability: [prefer-stable]
-                include:
-                    - laravel: 10.*
-                      testbench: 8.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -31,7 +32,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
                   composer update --${{ matrix.stability }} --prefer-dist --no-interaction
             - name: Analyse
               run: composer analyse

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.target_commitish }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,6 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer config allow-plugins.pestphp/pest-plugin true
                   composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
                   composer update --${{ matrix.stability }} --prefer-dist --no-interaction
             - name: Execute tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,10 @@
 name: coverage
 
-on: ['push', 'pull_request']
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [opened, synchronize, reopened]
 
 jobs:
     test:
@@ -9,18 +13,15 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2]
-                laravel: [10.*]
+                php: [8.2, 8.3]
+                laravel: ['10.*', '11.*']
                 stability: [prefer-stable]
-                include:
-                    - laravel: 10.*
-                      testbench: 8.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -32,7 +33,7 @@ jobs:
             - name: Install dependencies
               run: |
                   composer config allow-plugins.pestphp/pest-plugin true
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" pestphp/pest --no-interaction --no-update
+                  composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
                   composer update --${{ matrix.stability }} --prefer-dist --no-interaction
             - name: Execute tests
               run: XDEBUG_MODE=coverage php vendor/bin/pest --coverage --min=100

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,8 +2,10 @@ name: style
 
 on:
     push:
-        branches:
-            - main
+        branches: [main]
+    pull_request:
+        types: [opened, synchronize, reopened]
+        
 jobs:
     style:
         name: Style
@@ -11,7 +13,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: tests
 
-on: ['push', 'pull_request']
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [opened, synchronize, reopened]
 
 jobs:
     test:
@@ -10,17 +14,17 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 php: [8.1, 8.2, 8.3]
-                laravel: [10.*]
+                laravel: ['10.*', '11.*']
                 stability: [prefer-lowest, prefer-stable]
-                include:
-                    - laravel: 10.*
-                      testbench: 8.*
+                exclude:
+                    - php: 8.1
+                      laravel: '11.*'
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -31,7 +35,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
                   composer update --${{ matrix.stability }} --prefer-dist --no-interaction
             - name: Execute tests
               run: composer test

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/contracts": "^9.0|^10.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.7",
         "nunomaduro/larastan": "^2.5",
         "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^10.1",
-        "orchestra/testbench": "^8.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,12 @@
         "illuminate/contracts": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
+        "larastan/larastan": "^2.5",
         "laravel/pint": "^1.7",
-        "nunomaduro/larastan": "^2.5",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest-plugin-laravel": "^1.1|^2.0",
         "phpstan/phpstan-mockery": "^1.1",
-        "phpunit/phpunit": "^10.1",
-        "orchestra/testbench": "^8.0|^9.0|^10.0"
+        "phpunit/phpunit": "^10.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:

--- a/tests/Middleware/TrackPlausiblePageviewsTest.php
+++ b/tests/Middleware/TrackPlausiblePageviewsTest.php
@@ -5,12 +5,33 @@ namespace VincentBean\Plausible\Tests\Unit;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
 use VincentBean\Plausible\Middleware\TrackPlausiblePageviews;
 use VincentBean\Plausible\Tests\TestCase;
 
 class TrackPlausiblePageviewsTest extends TestCase
 {
     public function test_it_sends_event(): void
+    {
+        $post_url = 'http://plausible-domain.test/api/event';
+
+        Http::fake([$post_url => Http::response()]);
+
+        Route::middleware(TrackPlausiblePageviews::class)
+            ->get('/', fn () => 'Hello World');
+
+        $this->get('/');
+
+        Http::assertSent(function (Request $request) use ($post_url) {
+            return $request->hasHeader('X-Forwarded-For') &&
+                $request->hasHeader('user-agent') &&
+                $request->url() === $post_url &&
+                $request['name'] === 'pageview' &&
+                $request['domain'] === 'plausible-tracking-domain.test';
+        });
+    }
+
+    public function test_it_handles_event(): void
     {
         $post_url = 'http://plausible-domain.test/api/event';
 


### PR DESCRIPTION
This adds Laravel 11 support.

I've fixed:
* GitHub Actions:
    - don't trigger `push` event for Pull Requests.
    - you just need to set `illuminate/contracts` package version, and thanks to `orchestra/testbench` dependencies, the proper `laravel/framework` version is used.
* composer.json
    - renamed `nunomaduro/larastan`
    - added `pestphp/pest-plugin-laravel` and `pestphp/pest-plugin` plugin permanently
 * Tests: added a test for the middleware