### PR TITLE
Fix PlausibleEvent static method

### DIFF
--- a/src/Events/PlausibleEvent.php
+++ b/src/Events/PlausibleEvent.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Http;
 
 class PlausibleEvent
 {
+    /**
+     * Fire a Plausible event.
+     */    
     public static function fire(string $name, array $props = [], array $args = [], array $headers = []): bool
     {
         return Http::withHeaders(array_merge([

--- a/src/Events/PlausibleEvent.php
+++ b/src/Events/PlausibleEvent.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Http;
 
 class PlausibleEvent
 {
-    public function fire(string $name, array $props = [], array $args = [], array $headers = []): bool
+    public static function fire(string $name, array $props = [], array $args = [], array $headers = []): bool
     {
         return Http::withHeaders(array_merge([
             'X-Forwarded-For' => request()->ip(),


### PR DESCRIPTION
Sorry, my last changed introduced a regression, the `PlausibleEvent::fire` should be `static` for compatibility reasons.