### PR TITLE
Add try-catch to PlausibleEvent::fire to handle HTTP errors gracefully

### DIFF
--- a/src/Events/PlausibleEvent.php
+++ b/src/Events/PlausibleEvent.php
@@ -12,20 +12,29 @@ class PlausibleEvent
      */
     public static function fire(string $name, array $props = [], array $args = [], array $headers = []): bool
     {
-        return Http::withHeaders(array_merge([
-            'X-Forwarded-For' => request()->ip(),
-            'user-agent' => request()->userAgent(),
-        ], $headers))
-            ->post(
-                config('plausible.plausible_domain').'/api/event',
-                array_merge($args, [
-                    'name' => $name,
-                    'domain' => config('plausible.tracking_domain'),
-                    'url' => $args['url'] ?? url()->current(),
-                    'referrer' => Arr::get($headers, 'Referrer', request()->header('Referer')),
-                    'props' => json_encode($props),
-                ])
-            )
-            ->successful();
+        try {
+            return Http::withHeaders(array_merge([
+                'X-Forwarded-For' => request()->ip(),
+                'user-agent' => request()->userAgent(),
+            ], $headers))
+                ->post(
+                    config('plausible.plausible_domain').'/api/event',
+                    array_merge($args, [
+                        'name' => $name,
+                        'domain' => config('plausible.tracking_domain'),
+                        'url' => $args['url'] ?? url()->current(),
+                        'referrer' => Arr::get($headers, 'Referrer', request()->header('Referer')),
+                        'props' => json_encode($props),
+                    ])
+                )
+                ->successful();
+        }
+        catch (\Exception $e) {
+            # Log the error for debugging purposes
+            \Log::error('PlausibleEvent fire failed: '.$e->getMessage());
+
+            # Return false to gracefully handle the failure
+            return false;
+        }
     }
 }

--- a/src/Events/PlausibleEvent.php
+++ b/src/Events/PlausibleEvent.php
@@ -28,12 +28,11 @@ class PlausibleEvent
                     ])
                 )
                 ->successful();
-        }
-        catch (\Exception $e) {
-            # Log the error for debugging purposes
+        } catch (\Exception $e) {
+            // Log the error for debugging purposes
             \Log::error('PlausibleEvent fire failed: '.$e->getMessage());
 
-            # Return false to gracefully handle the failure
+            // Return false to gracefully handle the failure
             return false;
         }
     }

--- a/tests/Events/PlausibleEventTest.php
+++ b/tests/Events/PlausibleEventTest.php
@@ -104,6 +104,9 @@ class PlausibleEventTest extends TestCase
             $post_url => fn() => throw new \Illuminate\Http\Client\RequestException($mockResponse),
         ]);
 
+        # Spy on the log to capture any logged messages
+        \Log::spy();
+
         $name = $this->faker->word();
         $props = [$this->faker->word() => $this->faker->word()];
 
@@ -111,6 +114,13 @@ class PlausibleEventTest extends TestCase
         $result = PlausibleEvent::fire($name, $props);
 
         $this->assertFalse($result, 'The fire method should return false on exception');
+
+        # Verify that an error was logged
+        \Log::shouldHaveReceived('error')
+            ->once()
+            ->withArgs(function ($message) {
+                return str_contains($message, 'PlausibleEvent fire failed');
+            });
     }
 
 }

--- a/tests/Views/TrackingSnippetTest.php
+++ b/tests/Views/TrackingSnippetTest.php
@@ -10,7 +10,7 @@ class TrackingSnippetTest extends TestCase
 {
     use InteractsWithViews;
 
-    public function testRenderSnippet(): void
+    public function test_render_snippet(): void
     {
         $tracking_domain = config('plausible.tracking_domain');
         $domain = config('plausible.plausible_domain');
@@ -20,7 +20,7 @@ class TrackingSnippetTest extends TestCase
             ->assertSee('<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>', false);
     }
 
-    public function testRenderComponent(): void
+    public function test_render_component(): void
     {
         $tracking_domain = config('plausible.tracking_domain');
         $domain = config('plausible.plausible_domain');


### PR DESCRIPTION
### Summary
This PR adds a `try-catch` block to the `fire` method in `PlausibleEvent` to handle exceptions during HTTP requests gracefully.

### Details
- Wraps the HTTP request in a `try-catch` block.
- Logs any exceptions encountered.
- Returns `false` on failure instead of throwing an error.

### Why?
This change ensures that if the `PLAUSIBLE_DOMAIN` is unreachable or an unexpected error occurs, it does not crash the application with a 500 error.

### Tests
- Ensured the method returns `false` when an exception is triggered.
- Ensured the method returns `false` when an host is down or unreachable.

Let me know if any changes are needed!
