### PR TITLE
Add documentation for server side tracking via middleware in Laravel 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Laravel 11:
         // ...
         ->withMiddleware(function (Middleware $middleware) {
             // Append this middleware to track globally
-            $middleware->append(\VincentBean\Plausible\Middleware\TrackPlausiblePageviews::class);
+            $middleware->web(append: [\VincentBean\Plausible\Middleware\TrackPlausiblePageviews::class]);
         })
         // ...
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ plausible('event')
 ### Server Side Tracking
 Track pageviews server side using middleware.
 
+Laravel 11:
+```php
+// bootstrap/app.php
+    return Application::configure(basePath: dirname(__DIR__))
+        // ...
+        ->withMiddleware(function (Middleware $middleware) {
+            // Append this middleware to track globally
+            $middleware->append(\VincentBean\Plausible\Middleware\TrackPlausiblePageviews::class);
+        })
+        // ...
+```
+
+Laravel 10 and earlier versions:
 ```php
 // app/Http/Kernel.php
     'web' => [


### PR DESCRIPTION
In Laravel 11, the app/Http/Kernel.php file is no longer used. Middlewares can be appended in the bootstrap/app.php file: [https://laravel.com/docs/11.x/releases#structure](https://laravel.com/docs/11.x/releases#structure).

I've added this to the documentation so it's clear for users with a new Laravel 11 project where they should add the middleware for server side tracking.